### PR TITLE
[codex] Use shared release preparation workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -32,7 +32,7 @@ env:
 
 jobs:
   prepare_release:
-    uses: Plasius-LTD/plasius-ltd-site/.github/workflows/release-prepare.yml@main
+    uses: ./.github/workflows/release-prepare.yml
     with:
       bump: ${{ inputs.bump }}
       preid: ${{ inputs.preid }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -61,10 +61,10 @@ jobs:
           set -euo pipefail
 
           PUBLISHED="${{ needs.prepare_release.outputs.published }}"
-          SHOULD_PUBLISH="true"
+          SHOULD_PUBLISH_NPM="true"
           SKIP_REASON=""
           if [ "${PUBLISHED}" = "true" ]; then
-            SHOULD_PUBLISH="false"
+            SHOULD_PUBLISH_NPM="false"
             SKIP_REASON="Package version ${{ needs.prepare_release.outputs.version }} is already published; nothing to release."
           fi
 
@@ -73,20 +73,21 @@ jobs:
             echo "release_version=${{ needs.prepare_release.outputs.version }}"
             echo "release_tag=${{ needs.prepare_release.outputs.tag }}"
             echo "flags=${{ needs.prepare_release.outputs.flags }}"
-            echo "should_publish=${SHOULD_PUBLISH}"
+            echo "should_publish_npm=${SHOULD_PUBLISH_NPM}"
+            echo "should_finalize_release=true"
             echo "skip_reason=${SKIP_REASON}"
           } >> "$GITHUB_OUTPUT"
 
       - name: Skip when package version is already published
-        if: steps.release.outputs.should_publish != 'true'
+        if: steps.release.outputs.should_publish_npm != 'true'
         run: echo "${{ steps.release.outputs.skip_reason }}"
 
       - name: Install dependencies
-        if: steps.release.outputs.should_publish == 'true'
+        if: steps.release.outputs.should_finalize_release == 'true'
         run: npm ci
 
       - name: Run validation
-        if: steps.release.outputs.should_publish == 'true'
+        if: steps.release.outputs.should_finalize_release == 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -107,18 +108,18 @@ jobs:
           if has_script pack:check; then npm run pack:check; fi
 
       - name: Generate SBOM (CycloneDX)
-        if: steps.release.outputs.should_publish == 'true'
+        if: steps.release.outputs.should_finalize_release == 'true'
         run: npm sbom --sbom-format=cyclonedx --sbom-type=library --omit dev > sbom.cdx.json
         continue-on-error: true
 
       - name: Attest SBOM
-        if: steps.release.outputs.should_publish == 'true' && hashFiles('sbom.cdx.json') != ''
+        if: steps.release.outputs.should_finalize_release == 'true' && hashFiles('sbom.cdx.json') != ''
         uses: actions/attest-build-provenance@v3
         with:
           subject-path: sbom.cdx.json
 
       - name: Ensure release tag points at prepared commit
-        if: steps.release.outputs.should_publish == 'true'
+        if: steps.release.outputs.should_finalize_release == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.release.outputs.release_tag }}
@@ -153,7 +154,7 @@ jobs:
           git push origin "${TAG}"
 
       - name: Create GitHub Release draft
-        if: steps.release.outputs.should_publish == 'true'
+        if: steps.release.outputs.should_finalize_release == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.release.outputs.release_tag }}
@@ -186,7 +187,7 @@ jobs:
           fi
 
       - name: Publish package
-        if: steps.release.outputs.should_publish == 'true'
+        if: steps.release.outputs.should_publish_npm == 'true'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           FLAGS: ${{ steps.release.outputs.flags }}
@@ -200,7 +201,7 @@ jobs:
           npm publish ${FLAGS} --provenance --registry https://registry.npmjs.org
 
       - name: Publish GitHub Release
-        if: steps.release.outputs.should_publish == 'true'
+        if: steps.release.outputs.should_finalize_release == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.release.outputs.release_tag }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -21,6 +21,7 @@ on:
 permissions:
   actions: read
   contents: write
+  pull-requests: write
   id-token: write # for npm provenance (requires Node 18+ and npm >=9)
   attestations: write
 
@@ -30,6 +31,13 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
+  prepare_release:
+    uses: Plasius-LTD/plasius-ltd-site/.github/workflows/release-prepare.yml@main
+    with:
+      bump: ${{ inputs.bump }}
+      preid: ${{ inputs.preid }}
+    secrets: inherit
+
   select-runner:
     name: Select runner
     runs-on: ubuntu-latest
@@ -82,12 +90,17 @@ jobs:
             core.setOutput("runner_labels", selectedRunnerJson)
 
   publish:
-    needs: select-runner
+    needs:
+      - select-runner
+      - prepare_release
     runs-on: ${{ fromJSON(needs.select-runner.outputs.runner_labels) }}
     environment: production
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          ref: main
+          fetch-depth: 0
 
       - name: Use Node.js 24
         uses: actions/setup-node@v6
@@ -95,66 +108,17 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'npm'
 
-      - name: Bump version & decide publish flags
+      - name: Use prepared release metadata
         id: pkg
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          BUMP: ${{ inputs.bump }}
-          PREID: ${{ inputs.preid }}
         run: |
-          set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-          # Decide bump command
-          BUMP_CMD=""
-          case "${BUMP:-patch}" in
-            major|minor|patch)
-              if [ -n "${PREID:-}" ]; then
-                # Convert to pre* if preid provided
-                case "${BUMP}" in
-                  major) BUMP_CMD="npm version premajor --preid ${PREID} -m 'chore: release v%s [skip ci]'" ;;
-                  minor) BUMP_CMD="npm version preminor --preid ${PREID} -m 'chore: release v%s [skip ci]'" ;;
-                  patch) BUMP_CMD="npm version prepatch --preid ${PREID} -m 'chore: release v%s [skip ci]'" ;;
-                esac
-              else
-                BUMP_CMD="npm version ${BUMP} -m 'chore: release v%s [skip ci]'"
-              fi
-              ;;
-            none)
-              # No version bump; use existing version
-              BUMP_CMD="echo"
-              ;;
-            *)
-              echo "Unknown bump type: ${BUMP}" >&2
-              exit 1
-              ;;
-          esac
-
-          if [ "${BUMP}" = "none" ]; then
-            CURRENT_VER=$(node -p "require('./package.json').version")
-            NEW_VER="v${CURRENT_VER}"
-          else
-            # shellcheck disable=SC2086
-            NEW_VER=$(sh -lc "$BUMP_CMD")
-          fi
-
-          echo "New version: $NEW_VER"
-          git push --follow-tags
-
-          # Expose tag (vX.Y.Z) and version (X.Y.Z) for later steps
-          VER_NO_V=${NEW_VER#v}
-          echo "tag=$NEW_VER" >> "$GITHUB_OUTPUT"
-          echo "version=$VER_NO_V" >> "$GITHUB_OUTPUT"
-
-          NAME=$(node -p "require('./package.json').name")
-          echo "name=$NAME" >> "$GITHUB_OUTPUT"
-          if npm view "$NAME" version >/dev/null 2>&1; then
-            echo "flags=" >> "$GITHUB_OUTPUT"
-          else
-            echo "flags=--access public" >> "$GITHUB_OUTPUT"
-          fi
-
+          {
+            echo "mode=publish"
+            echo "name=${{ needs.prepare_release.outputs.name }}"
+            echo "tag=${{ needs.prepare_release.outputs.tag }}"
+            echo "version=${{ needs.prepare_release.outputs.version }}"
+            echo "flags=${{ needs.prepare_release.outputs.flags }}"
+            echo "published=${{ needs.prepare_release.outputs.published }}"
+          } >> "$GITHUB_OUTPUT"
       - name: Install deps (CI)
         run: npm ci
 
@@ -184,96 +148,30 @@ jobs:
         with:
           subject-path: sbom.cdx.json
 
-      - name: Update CHANGELOG.md (move Unreleased to new version)
+      - name: Create release tag from main
         env:
-          VERSION: ${{ steps.pkg.outputs.version }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.pkg.outputs.tag }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          verbose: true
         run: |
           set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch origin main --tags
+          git checkout -B main origin/main
 
-          FILE="CHANGELOG.md"
-          if [ ! -f "$FILE" ]; then
-            echo "No CHANGELOG.md found; skipping changelog update."
-            exit 0
-          fi
-
-          if grep -q "^## \[${VERSION}\]" "$FILE"; then
-            echo "CHANGELOG.md already contains a ${VERSION} release section; skipping changelog update."
-            exit 0
-          fi
-
-          DATE=$(date -u +%Y-%m-%d)
-          VERSION_LINE="## [${VERSION}] - ${DATE}"
-
-          # Identify Unreleased block boundaries
-          UNREL_START=$(grep -n '^## \[Unreleased\]' "$FILE" | cut -d: -f1 || true)
-          if [ -z "$UNREL_START" ]; then
-            echo "No '## [Unreleased]' section found; skipping changelog update."
-            exit 0
-          fi
-          NEXT_HDR=$(awk 'NR>'"$UNREL_START"' && /^## \[/{print NR; exit}' "$FILE")
-          if [ -z "$NEXT_HDR" ]; then
-            NEXT_HDR=$(wc -l < "$FILE")
-            NEXT_HDR=$((NEXT_HDR+1))
-          fi
-
-          # Extract sections
-          HEADER=$(sed -n "1,${UNREL_START}p" "$FILE")
-          UNREL_CONTENT=$(sed -n "$((UNREL_START+1)),$((NEXT_HDR-1))p" "$FILE")
-          TAIL=$(sed -n "${NEXT_HDR},\$p" "$FILE")
-
-          # Prepare new Unreleased template (Keep a Changelog style) without tabs/indent issues
-          NEW_UNRELEASED=$(printf '%s\n' \
-            '' \
-            '- **Added**' \
-            '  - (placeholder)' \
-            '' \
-            '- **Changed**' \
-            '  - (placeholder)' \
-            '' \
-            '- **Fixed**' \
-            '  - (placeholder)' \
-            '' \
-            '- **Security**' \
-            '  - (placeholder)')
-
-          # Build the new CHANGELOG content
-          TMP_FILE=$(mktemp)
-          {
-            printf "%s\n" "$HEADER"
-            printf "%s\n\n" "$NEW_UNRELEASED"
-            printf "%s\n" "$VERSION_LINE"
-            # If Unreleased was empty, at least add a placeholder so the section isn't blank
-            if [ -z "$(echo "$UNREL_CONTENT" | tr -d '\n' | tr -d '[:space:]')" ]; then
-              printf "### Changed\n- (no notable changes)\n\n"
-            else
-              printf "%s\n" "$UNREL_CONTENT"
-              # Ensure a trailing newline after the inserted section
-              printf "\n"
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            if gh release view "${TAG}" >/dev/null 2>&1; then
+              IS_DRAFT="$(gh release view "${TAG}" --json isDraft --jq '.isDraft')"
+              if [ "${IS_DRAFT}" != "true" ]; then
+                echo "Published release ${TAG} already exists; reusing the existing tag."
+                exit 0
+              fi
             fi
-            printf "%s\n" "$TAIL"
-          } > "$TMP_FILE"
 
-          mv "$TMP_FILE" "$FILE"
-
-          # Update bottom compare links
-          # Update [Unreleased] compare to start at v${VERSION}
-          COMPARE_URL="https://github.com/${GITHUB_REPOSITORY}/compare/v${VERSION}...HEAD"
-          awk -v repl="[Unreleased]: ${COMPARE_URL}" 'BEGIN{OFS=FS} { if ($0 ~ /^\[Unreleased\]: /) { print repl } else { print } }' "$FILE" > "$FILE.tmp"
-          mv "$FILE.tmp" "$FILE"
-
-          # Append a link for the new version if not present
-          if ! grep -q "^\[${VERSION}\]:" "$FILE"; then
-            echo "[${VERSION}]: https://github.com/${GITHUB_REPOSITORY}/releases/tag/v${VERSION}" >> "$FILE"
+            echo "Deleting stale unpublished tag ${TAG} before recreating it from main."
+            git push origin ":refs/tags/${TAG}"
           fi
 
-          git add "$FILE"
-          git commit -m "docs(changelog): release v${VERSION}"
-          git push
+          git tag "${TAG}"
+          git push origin "${TAG}"
 
       - name: Create GitHub Release draft (immutable-safe)
         env:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,15 +20,14 @@ on:
 
 permissions:
   actions: read
-  contents: write
-  pull-requests: write
-  id-token: write # for npm provenance (requires Node 18+ and npm >=9)
   attestations: write
+  contents: write
+  id-token: write
+  pull-requests: write
 
-env:
-  FALLBACK_RUNNER_LABEL: ubuntu-latest
-  SELF_HOSTED_RUNNER_LABELS: '["self-hosted","Linux","X64"]'
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+concurrency:
+  group: npm-cd-${{ github.repository }}
+  cancel-in-progress: false
 
 jobs:
   prepare_release:
@@ -38,188 +37,183 @@ jobs:
       preid: ${{ inputs.preid }}
     secrets: inherit
 
-  select-runner:
-    name: Select runner
-    runs-on: ubuntu-latest
-    outputs:
-      runner_labels: ${{ steps.select.outputs.runner_labels }}
-    steps:
-      - name: Prefer idle self-hosted runner
-        id: select
-        uses: actions/github-script@v9
-        with:
-          github-token: ${{ secrets.RUNNER_SELECTOR_TOKEN || github.token }}
-          script: |
-            const selfHostedLabels = JSON.parse(process.env.SELF_HOSTED_RUNNER_LABELS)
-            const fallbackRunner = process.env.FALLBACK_RUNNER_LABEL
-            let selectedRunnerJson = JSON.stringify(fallbackRunner)
-
-            try {
-              const runners = await github.paginate(
-                github.rest.actions.listSelfHostedRunnersForRepo,
-                {
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  per_page: 100,
-                }
-              )
-
-              const hasMatchingIdleRunner = runners.some((runner) => {
-                const labels = new Set((runner.labels || []).map((label) => label.name))
-                return (
-                  runner.status === "online" &&
-                  runner.busy === false &&
-                  selfHostedLabels.every((label) => labels.has(label))
-                )
-              })
-
-              if (hasMatchingIdleRunner) {
-                selectedRunnerJson = JSON.stringify(selfHostedLabels)
-                core.info(`Selected self-hosted runner labels ${selfHostedLabels.join(", ")}.`)
-              } else {
-                core.info(
-                  `No idle self-hosted runner with labels ${selfHostedLabels.join(", ")} was found; falling back to ${fallbackRunner}.`
-                )
-              }
-            } catch (error) {
-              core.warning(
-                `Could not inspect self-hosted runners; falling back to ${fallbackRunner}. ${error.message}`
-              )
-            }
-
-            core.setOutput("runner_labels", selectedRunnerJson)
-
   publish:
-    needs:
-      - select-runner
-      - prepare_release
-    runs-on: ${{ fromJSON(needs.select-runner.outputs.runner_labels) }}
+    needs: prepare_release
+    runs-on: ubuntu-latest
     environment: production
     steps:
-      - name: Checkout
-        uses: actions/checkout@v5
+      - name: Checkout prepared release commit
+        uses: actions/checkout@v4
         with:
-          ref: main
+          ref: ${{ needs.prepare_release.outputs.commit_sha }}
           fetch-depth: 0
 
       - name: Use Node.js 24
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
+          node-version-file: ".nvmrc"
+          registry-url: "https://registry.npmjs.org"
+          cache: npm
 
       - name: Use prepared release metadata
-        id: pkg
+        id: release
         run: |
+          set -euo pipefail
+
+          PUBLISHED="${{ needs.prepare_release.outputs.published }}"
+          SHOULD_PUBLISH="true"
+          SKIP_REASON=""
+          if [ "${PUBLISHED}" = "true" ]; then
+            SHOULD_PUBLISH="false"
+            SKIP_REASON="Package version ${{ needs.prepare_release.outputs.version }} is already published; nothing to release."
+          fi
+
           {
-            echo "mode=publish"
-            echo "name=${{ needs.prepare_release.outputs.name }}"
-            echo "tag=${{ needs.prepare_release.outputs.tag }}"
-            echo "version=${{ needs.prepare_release.outputs.version }}"
+            echo "package_name=${{ needs.prepare_release.outputs.name }}"
+            echo "release_version=${{ needs.prepare_release.outputs.version }}"
+            echo "release_tag=${{ needs.prepare_release.outputs.tag }}"
             echo "flags=${{ needs.prepare_release.outputs.flags }}"
-            echo "published=${{ needs.prepare_release.outputs.published }}"
+            echo "should_publish=${SHOULD_PUBLISH}"
+            echo "skip_reason=${SKIP_REASON}"
           } >> "$GITHUB_OUTPUT"
-      - name: Install deps (CI)
+
+      - name: Skip when package version is already published
+        if: steps.release.outputs.should_publish != 'true'
+        run: echo "${{ steps.release.outputs.skip_reason }}"
+
+      - name: Install dependencies
+        if: steps.release.outputs.should_publish == 'true'
         run: npm ci
 
-      - name: Test (coverage)
-        run: npm run test:coverage
-
-      - name: Install Codecov CLI
-        run: python3 -m pip install --upgrade codecov-cli
-
-      - name: Upload coverage to Codecov
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      - name: Run validation
+        if: steps.release.outputs.should_publish == 'true'
+        shell: bash
         run: |
-          codecovcli --verbose upload-process --disable-search --fail-on-error \
-            -n "release-${GITHUB_RUN_ID}" \
-            -F unittests \
-            -f ./coverage/lcov.info
+          set -euo pipefail
 
-      - name: Build
-        run: npm run build --if-present
+          has_script() {
+            node -e "const scripts = require('./package.json').scripts || {}; process.exit(scripts[process.argv[1]] ? 0 : 1)" "$1"
+          }
+
+          if has_script lint; then npm run lint; fi
+          if has_script typecheck; then npm run typecheck; fi
+          if has_script audit:npm; then npm run audit:npm; fi
+          if has_script build; then npm run build; fi
+          if has_script test:coverage; then
+            npm run test:coverage
+          elif has_script test; then
+            npm test
+          fi
+          if has_script pack:check; then npm run pack:check; fi
 
       - name: Generate SBOM (CycloneDX)
+        if: steps.release.outputs.should_publish == 'true'
         run: npm sbom --sbom-format=cyclonedx --sbom-type=library --omit dev > sbom.cdx.json
+        continue-on-error: true
 
-      - name: Attest SBOM (GitHub Artifact Attestations)
+      - name: Attest SBOM
+        if: steps.release.outputs.should_publish == 'true' && hashFiles('sbom.cdx.json') != ''
         uses: actions/attest-build-provenance@v3
         with:
           subject-path: sbom.cdx.json
 
-      - name: Create release tag from main
+      - name: Ensure release tag points at prepared commit
+        if: steps.release.outputs.should_publish == 'true'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ steps.pkg.outputs.tag }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.release.outputs.release_tag }}
         run: |
           set -euo pipefail
-          git fetch origin main --tags
-          git checkout -B main origin/main
+
+          HEAD_SHA="$(git rev-parse HEAD)"
+          git fetch origin --tags --force
 
           if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            git fetch origin "refs/tags/${TAG}:refs/tags/${TAG}" --force
+            TAG_SHA="$(git rev-list -n 1 "${TAG}")"
+            if [ "${TAG_SHA}" = "${HEAD_SHA}" ]; then
+              echo "Tag ${TAG} already points at prepared commit ${HEAD_SHA}."
+              exit 0
+            fi
+
             if gh release view "${TAG}" >/dev/null 2>&1; then
               IS_DRAFT="$(gh release view "${TAG}" --json isDraft --jq '.isDraft')"
               if [ "${IS_DRAFT}" != "true" ]; then
-                echo "Published release ${TAG} already exists; reusing the existing tag."
-                exit 0
+                echo "Release ${TAG} already exists and is published at ${TAG_SHA}; cut a new version instead." >&2
+                exit 1
               fi
             fi
 
-            echo "Deleting stale unpublished tag ${TAG} before recreating it from main."
+            echo "Replacing stale unpublished tag ${TAG}."
             git push origin ":refs/tags/${TAG}"
+            git tag -d "${TAG}" >/dev/null 2>&1 || true
           fi
 
-          git tag "${TAG}"
+          git tag "${TAG}" "${HEAD_SHA}"
           git push origin "${TAG}"
 
-      - name: Create GitHub Release draft (immutable-safe)
+      - name: Create GitHub Release draft
+        if: steps.release.outputs.should_publish == 'true'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.release.outputs.release_tag }}
+          PREID: ${{ inputs.preid }}
         run: |
           set -euo pipefail
-          TAG="${{ steps.pkg.outputs.tag }}"
-          if gh release view "$TAG" >/dev/null 2>&1; then
-            IS_DRAFT="$(gh release view "$TAG" --json isDraft --jq '.isDraft')"
-            if [ "$IS_DRAFT" != "true" ]; then
-              echo "Release $TAG already exists and is published. Immutable releases cannot be modified after publication; cut a new version instead."
+
+          if gh release view "${TAG}" >/dev/null 2>&1; then
+            IS_DRAFT="$(gh release view "${TAG}" --json isDraft --jq '.isDraft')"
+            if [ "${IS_DRAFT}" != "true" ]; then
+              echo "Release ${TAG} already exists and is published. Cut a new version instead." >&2
               exit 1
             fi
 
-            echo "Draft release $TAG already exists; refreshing mutable assets."
-            if [ -f sbom.cdx.json ]; then
-              gh release upload "$TAG" sbom.cdx.json --clobber
-            else
-              echo "No SBOM generated; leaving existing draft assets unchanged."
+            if [ -s sbom.cdx.json ]; then
+              gh release upload "${TAG}" sbom.cdx.json --clobber
             fi
-          else
-            if [ -f sbom.cdx.json ]; then
-              gh release create "$TAG" sbom.cdx.json                 --title "Release $TAG"                 --generate-notes                 --verify-tag                 --draft
-            else
-              gh release create "$TAG"                 --title "Release $TAG"                 --generate-notes                 --verify-tag                 --draft
-            fi
+            exit 0
           fi
 
-      - name: Publish
+          ARGS=(--title "Release ${TAG}" --generate-notes --verify-tag --draft)
+          if [ -n "${PREID}" ]; then
+            ARGS+=(--prerelease)
+          fi
+
+          if [ -s sbom.cdx.json ]; then
+            gh release create "${TAG}" sbom.cdx.json "${ARGS[@]}"
+          else
+            gh release create "${TAG}" "${ARGS[@]}"
+          fi
+
+      - name: Publish package
+        if: steps.release.outputs.should_publish == 'true'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          npm publish ${{ steps.pkg.outputs.flags }} --provenance
-
-      - name: Publish GitHub Release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FLAGS: ${{ steps.release.outputs.flags }}
         run: |
           set -euo pipefail
-          TAG="${{ steps.pkg.outputs.tag }}"
-          if ! gh release view "$TAG" >/dev/null 2>&1; then
-            echo "Expected draft release $TAG to exist before publication."
+          if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
+            echo "NPM_TOKEN is required" >&2
             exit 1
           fi
 
-          IS_DRAFT="$(gh release view "$TAG" --json isDraft --jq '.isDraft')"
-          if [ "$IS_DRAFT" = "true" ]; then
-            gh release edit "$TAG" --draft=false --latest
+          npm publish ${FLAGS} --provenance --registry https://registry.npmjs.org
+
+      - name: Publish GitHub Release
+        if: steps.release.outputs.should_publish == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.release.outputs.release_tag }}
+          PREID: ${{ inputs.preid }}
+        run: |
+          set -euo pipefail
+          if ! gh release view "${TAG}" >/dev/null 2>&1; then
+            echo "Expected draft release ${TAG} to exist before publication." >&2
+            exit 1
+          fi
+
+          if [ -n "${PREID}" ]; then
+            gh release edit "${TAG}" --draft=false --prerelease
           else
-            echo "Release $TAG is already published; skipping publication."
+            gh release edit "${TAG}" --draft=false --latest
           fi

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -1,0 +1,430 @@
+name: Release Prepare
+
+on:
+  workflow_call:
+    inputs:
+      bump:
+        description: "Version bump type"
+        required: true
+        type: string
+      preid:
+        description: "Pre-release id (for example beta or rc). Leave blank for stable."
+        required: false
+        type: string
+      base_branch:
+        description: "Protected branch that must receive release metadata before publishing."
+        required: false
+        type: string
+        default: main
+      package_directory:
+        description: "Directory containing the package.json to version."
+        required: false
+        type: string
+        default: "."
+      changelog_path:
+        description: "CHANGELOG.md path to promote for this release."
+        required: false
+        type: string
+        default: "CHANGELOG.md"
+      tag_prefix:
+        description: "Prefix for release tags, for example v or ui-foundry-core-v."
+        required: false
+        type: string
+        default: "v"
+      merge_timeout_seconds:
+        description: "How long to wait for a release-prep PR to merge before failing."
+        required: false
+        type: string
+        default: "1200"
+    outputs:
+      name:
+        description: "npm package name"
+        value: ${{ jobs.prepare.outputs.name }}
+      version:
+        description: "Prepared package version without leading v"
+        value: ${{ jobs.prepare.outputs.version }}
+      tag:
+        description: "Prepared release tag"
+        value: ${{ jobs.prepare.outputs.tag }}
+      flags:
+        description: "npm publish flags"
+        value: ${{ jobs.prepare.outputs.flags }}
+      published:
+        description: "Whether this exact package version already exists on npm"
+        value: ${{ jobs.prepare.outputs.published }}
+      commit_sha:
+        description: "main commit containing the release metadata"
+        value: ${{ jobs.prepare.outputs.commit_sha }}
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      name: ${{ steps.release.outputs.name }}
+      version: ${{ steps.release.outputs.version }}
+      tag: ${{ steps.release.outputs.tag }}
+      flags: ${{ steps.release.outputs.flags }}
+      published: ${{ steps.release.outputs.published }}
+      commit_sha: ${{ steps.release.outputs.commit_sha }}
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.base_branch }}
+          fetch-depth: 0
+
+      - name: Use Node.js 24
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - name: Prepare and land release metadata
+        id: release
+        env:
+          BASE_BRANCH: ${{ inputs.base_branch }}
+          BUMP: ${{ inputs.bump }}
+          PREID: ${{ inputs.preid }}
+          PACKAGE_DIRECTORY: ${{ inputs.package_directory }}
+          CHANGELOG_PATH: ${{ inputs.changelog_path }}
+          TAG_PREFIX: ${{ inputs.tag_prefix }}
+          MERGE_TIMEOUT_SECONDS: ${{ inputs.merge_timeout_seconds }}
+          GITHUB_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.RELEASE_PREP_TOKEN || github.token }}
+          RELEASE_PREP_TOKEN: ${{ secrets.RELEASE_PREP_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          if [ "${GITHUB_REF_NAME:-}" != "${BASE_BRANCH}" ]; then
+            echo "Run cd.yml from ${BASE_BRANCH}; release metadata must be prepared from the protected release branch." >&2
+            exit 1
+          fi
+
+          AUTH_TOKEN="${RELEASE_PREP_TOKEN:-${GITHUB_TOKEN}}"
+          git remote set-url origin "https://x-access-token:${AUTH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git fetch origin "${BASE_BRANCH}" --tags
+          git checkout -B "${BASE_BRANCH}" "origin/${BASE_BRANCH}"
+
+          PACKAGE_DIRECTORY="${PACKAGE_DIRECTORY%/}"
+          if [ -z "${PACKAGE_DIRECTORY}" ]; then
+            PACKAGE_DIRECTORY="."
+          fi
+
+          if [ "${PACKAGE_DIRECTORY}" = "." ]; then
+            PACKAGE_JSON="package.json"
+          else
+            PACKAGE_JSON="${PACKAGE_DIRECTORY}/package.json"
+          fi
+
+          if [ ! -f "${PACKAGE_JSON}" ]; then
+            echo "Package manifest not found: ${PACKAGE_JSON}" >&2
+            exit 1
+          fi
+
+          NAME=$(PACKAGE_JSON_PATH="${PACKAGE_JSON}" node -p "const path = require('node:path'); const pkg = require(path.resolve(process.env.PACKAGE_JSON_PATH)); pkg.name || ''")
+          CURRENT_VER=$(PACKAGE_JSON_PATH="${PACKAGE_JSON}" node -p "const path = require('node:path'); const pkg = require(path.resolve(process.env.PACKAGE_JSON_PATH)); pkg.version || ''")
+          PRIVATE_PACKAGE=$(PACKAGE_JSON_PATH="${PACKAGE_JSON}" node -p "const path = require('node:path'); const pkg = require(path.resolve(process.env.PACKAGE_JSON_PATH)); String(Boolean(pkg.private))")
+
+          if [ -z "${NAME}" ] || [ -z "${CURRENT_VER}" ]; then
+            echo "${PACKAGE_JSON} must define package name and version." >&2
+            exit 1
+          fi
+
+          if [ "${PRIVATE_PACKAGE}" = "true" ]; then
+            echo "Cannot release private package ${NAME} from ${PACKAGE_JSON}." >&2
+            exit 1
+          fi
+
+          REGISTRY_VER="$(npm view "${NAME}" version 2>/dev/null || true)"
+          TAG_VER=$(
+            git tag -l "${TAG_PREFIX}*" |
+              TAG_PREFIX="${TAG_PREFIX}" node <<'NODE'
+          const fs = require("node:fs");
+          const prefix = process.env.TAG_PREFIX || "v";
+          const parse = (value) => {
+            const trimmed = String(value || "").trim();
+            if (!trimmed.startsWith(prefix)) return null;
+            const version = trimmed.slice(prefix.length).replace(/\^\{\}$/, "");
+            const [core, prerelease = ""] = version.split("-");
+            const parts = core.split(".").map((part) => Number(part));
+            if (parts.length !== 3 || parts.some((part) => !Number.isInteger(part) || part < 0)) {
+              return null;
+            }
+            return { version, parts, prerelease };
+          };
+          const compare = (left, right) => {
+            for (let index = 0; index < 3; index += 1) {
+              const diff = left.parts[index] - right.parts[index];
+              if (diff !== 0) return diff;
+            }
+            if (left.prerelease === right.prerelease) return 0;
+            if (!left.prerelease) return 1;
+            if (!right.prerelease) return -1;
+            return left.prerelease.localeCompare(right.prerelease, undefined, { numeric: true });
+          };
+
+          const versions = fs
+            .readFileSync(0, "utf8")
+            .split(/\r?\n/)
+            .map(parse)
+            .filter(Boolean)
+            .sort(compare);
+
+          process.stdout.write(versions.at(-1)?.version || "");
+          NODE
+          )
+
+          case "${BUMP:-patch}" in
+            major|minor|patch|none) ;;
+            *)
+              echo "Unknown bump type: ${BUMP}" >&2
+              exit 1
+              ;;
+          esac
+
+          if [ "${BUMP}" = "none" ]; then
+            TARGET_VER="${CURRENT_VER}"
+          else
+            TARGET_VER=$(node -e '
+          const [localVersion, registryVersion, tagVersion, bump, preid] = process.argv.slice(1);
+          const clean = (value) => String(value || "").replace(/^v/, "").trim();
+          const parse = (value) => {
+            const [core] = clean(value).split("-");
+            const parts = core.split(".").map((part) => Number(part));
+            if (parts.length !== 3 || parts.some((part) => !Number.isInteger(part) || part < 0)) {
+              throw new Error(`Invalid semver value: ${value}`);
+            }
+            return parts;
+          };
+          const compare = (left, right) => {
+            for (let index = 0; index < 3; index += 1) {
+              const diff = left[index] - right[index];
+              if (diff !== 0) return diff;
+            }
+            return 0;
+          };
+
+          const candidates = [localVersion, registryVersion, tagVersion].filter(Boolean).map(parse);
+          let base = candidates[0];
+          for (const candidate of candidates.slice(1)) {
+            if (compare(candidate, base) > 0) base = candidate;
+          }
+
+          let next;
+          switch (bump) {
+            case "major":
+              next = [base[0] + 1, 0, 0];
+              break;
+            case "minor":
+              next = [base[0], base[1] + 1, 0];
+              break;
+            case "patch":
+              next = [base[0], base[1], base[2] + 1];
+              break;
+            default:
+              throw new Error(`Unknown bump type: ${bump}`);
+          }
+
+          let version = next.join(".");
+          if (preid) {
+            version = `${version}-${preid}.0`;
+          }
+          process.stdout.write(version);
+          ' "${CURRENT_VER}" "${REGISTRY_VER}" "${TAG_VER}" "${BUMP}" "${PREID:-}")
+            if [ "${PACKAGE_DIRECTORY}" = "." ]; then
+              npm version "${TARGET_VER}" --no-git-tag-version --allow-same-version
+            else
+              npm version "${TARGET_VER}" --workspace "${PACKAGE_DIRECTORY}" --no-git-tag-version --allow-same-version
+            fi
+          fi
+
+          TAG="${TAG_PREFIX}${TARGET_VER}"
+
+          if npm view "${NAME}@${TARGET_VER}" version >/dev/null 2>&1; then
+            PUBLISHED="true"
+          else
+            PUBLISHED="false"
+          fi
+
+          if [ "${BUMP}" != "none" ] && [ "${PUBLISHED}" = "true" ]; then
+            echo "${NAME}@${TARGET_VER} already exists on npm; cut a new version instead." >&2
+            exit 1
+          fi
+
+          if [ "${BUMP}" != "none" ] && gh release view "${TAG}" >/dev/null 2>&1; then
+            IS_DRAFT="$(gh release view "${TAG}" --json isDraft --jq '.isDraft')"
+            if [ "${IS_DRAFT}" != "true" ]; then
+              echo "GitHub release ${TAG} is already published; cut a new version instead." >&2
+              exit 1
+            fi
+          fi
+
+          FILE="${CHANGELOG_PATH}"
+          if [ ! -f "${FILE}" ]; then
+            echo "CHANGELOG.md is required for release metadata preparation." >&2
+            exit 1
+          fi
+
+          if ! grep -q "^## \[${TARGET_VER}\]" "${FILE}"; then
+            UNREL_START=$(grep -n '^## \[Unreleased\]' "${FILE}" | cut -d: -f1 || true)
+            if [ -z "${UNREL_START}" ]; then
+              echo "No '## [Unreleased]' section found in CHANGELOG.md." >&2
+              exit 1
+            fi
+
+            DATE=$(date -u +%Y-%m-%d)
+            VERSION_LINE="## [${TARGET_VER}] - ${DATE}"
+            NEXT_HDR=$(awk 'NR>'"${UNREL_START}"' && /^## \[/{print NR; exit}' "${FILE}")
+            if [ -z "${NEXT_HDR}" ]; then
+              NEXT_HDR=$(wc -l < "${FILE}")
+              NEXT_HDR=$((NEXT_HDR+1))
+            fi
+
+            HEADER=$(sed -n "1,${UNREL_START}p" "${FILE}")
+            UNREL_CONTENT=$(sed -n "$((UNREL_START+1)),$((NEXT_HDR-1))p" "${FILE}")
+            TAIL=$(sed -n "${NEXT_HDR},\$p" "${FILE}")
+
+            NEW_UNRELEASED=$(printf '%s\n' \
+              '' \
+              '- **Added**' \
+              '  - (placeholder)' \
+              '' \
+              '- **Changed**' \
+              '  - (placeholder)' \
+              '' \
+              '- **Fixed**' \
+              '  - (placeholder)' \
+              '' \
+              '- **Security**' \
+              '  - (placeholder)')
+
+            TMP_FILE=$(mktemp)
+            {
+              printf "%s\n" "${HEADER}"
+              printf "%s\n\n" "${NEW_UNRELEASED}"
+              printf "%s\n" "${VERSION_LINE}"
+              if [ -z "$(echo "${UNREL_CONTENT}" | tr -d '\n' | tr -d '[:space:]')" ]; then
+                printf "### Changed\n- (no notable changes)\n\n"
+              else
+                printf "%s\n" "${UNREL_CONTENT}"
+                printf "\n"
+              fi
+              printf "%s\n" "${TAIL}"
+            } > "${TMP_FILE}"
+
+            mv "${TMP_FILE}" "${FILE}"
+
+            COMPARE_URL="https://github.com/${GITHUB_REPOSITORY}/compare/${TAG}...HEAD"
+            awk -v repl="[Unreleased]: ${COMPARE_URL}" 'BEGIN{OFS=FS} { if ($0 ~ /^\[Unreleased\]: /) { print repl } else { print } }' "${FILE}" > "${FILE}.tmp"
+            mv "${FILE}.tmp" "${FILE}"
+
+            if ! grep -q "^\[${TARGET_VER}\]:" "${FILE}"; then
+              echo "[${TARGET_VER}]: https://github.com/${GITHUB_REPOSITORY}/releases/tag/${TAG}" >> "${FILE}"
+            fi
+          fi
+
+          git add "${PACKAGE_JSON}"
+          if [ -f package-lock.json ]; then
+            git add package-lock.json
+          fi
+          if [ "${PACKAGE_DIRECTORY}" != "." ] && [ -f "${PACKAGE_DIRECTORY}/package-lock.json" ]; then
+            git add "${PACKAGE_DIRECTORY}/package-lock.json"
+          fi
+          git add "${FILE}"
+
+          if git diff --cached --quiet; then
+            echo "Release metadata already exists on ${BASE_BRANCH} for ${TAG}."
+          else
+            git commit -m "chore: prepare release ${TAG}"
+
+            if git push origin "HEAD:${BASE_BRANCH}"; then
+              echo "Release metadata pushed directly to ${BASE_BRANCH}."
+            else
+              BRANCH="release/${TAG}"
+              git push --force-with-lease --set-upstream origin "HEAD:${BRANCH}"
+
+              PR_TITLE="chore: prepare release ${TAG}"
+              PR_BODY=$(cat <<EOF
+          ## Summary
+          - prepare \`${TAG}\` for publication from protected \`${BASE_BRANCH}\`
+          - update package metadata to \`${TARGET_VER}\`
+          - move the current \`Unreleased\` notes into \`${TARGET_VER}\`
+
+          The CD workflow will continue only after this release metadata is present on \`${BASE_BRANCH}\`.
+          EOF
+          )
+
+              PR_NUMBER="$(gh pr list --head "${BRANCH}" --base "${BASE_BRANCH}" --state open --json number --jq '.[0].number' || true)"
+              if [ -n "${PR_NUMBER}" ] && [ "${PR_NUMBER}" != "null" ]; then
+                gh pr edit "${PR_NUMBER}" --title "${PR_TITLE}" --body "${PR_BODY}"
+              else
+                PR_URL="$(gh pr create --base "${BASE_BRANCH}" --head "${BRANCH}" --title "${PR_TITLE}" --body "${PR_BODY}")"
+                PR_NUMBER="$(gh pr view "${PR_URL}" --json number --jq '.number')"
+              fi
+
+              if gh pr merge "${PR_NUMBER}" --squash --delete-branch; then
+                echo "Release metadata PR #${PR_NUMBER} merged."
+              else
+                echo "Immediate merge was not available for release metadata PR #${PR_NUMBER}; enabling auto-merge and waiting."
+                gh pr merge "${PR_NUMBER}" --auto --squash --delete-branch || true
+
+                DEADLINE=$((SECONDS + MERGE_TIMEOUT_SECONDS))
+                while [ "${SECONDS}" -lt "${DEADLINE}" ]; do
+                  STATE="$(gh pr view "${PR_NUMBER}" --json state --jq '.state')"
+                  if [ "${STATE}" = "MERGED" ]; then
+                    echo "Release metadata PR #${PR_NUMBER} merged."
+                    break
+                  fi
+                  if [ "${STATE}" = "CLOSED" ]; then
+                    echo "Release metadata PR #${PR_NUMBER} closed without merging." >&2
+                    exit 1
+                  fi
+                  sleep 10
+                done
+
+                STATE="$(gh pr view "${PR_NUMBER}" --json state --jq '.state')"
+                if [ "${STATE}" != "MERGED" ]; then
+                  echo "Release metadata PR #${PR_NUMBER} did not merge within ${MERGE_TIMEOUT_SECONDS}s; release will not continue until ${BASE_BRANCH} contains ${TAG}." >&2
+                  exit 1
+                fi
+              fi
+            fi
+          fi
+
+          git fetch origin "${BASE_BRANCH}" --tags
+          git checkout -B "${BASE_BRANCH}" "origin/${BASE_BRANCH}"
+
+          MAIN_VERSION=$(PACKAGE_JSON_PATH="${PACKAGE_JSON}" node -p "const path = require('node:path'); const pkg = require(path.resolve(process.env.PACKAGE_JSON_PATH)); pkg.version || ''")
+          if [ "${MAIN_VERSION}" != "${TARGET_VER}" ]; then
+            echo "${BASE_BRANCH} has package version ${MAIN_VERSION}, expected ${TARGET_VER}." >&2
+            exit 1
+          fi
+
+          if ! grep -q "^## \[${TARGET_VER}\]" "${FILE}"; then
+            echo "${BASE_BRANCH} is missing ${FILE} release section ${TARGET_VER}." >&2
+            exit 1
+          fi
+
+          if npm view "${NAME}" version >/dev/null 2>&1; then
+            FLAGS=""
+          else
+            FLAGS="--access public"
+          fi
+
+          COMMIT_SHA=$(git rev-parse HEAD)
+          {
+            echo "name=${NAME}"
+            echo "version=${TARGET_VER}"
+            echo "tag=${TAG}"
+            echo "flags=${FLAGS}"
+            echo "published=${PUBLISHED}"
+            echo "commit_sha=${COMMIT_SHA}"
+          } >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -64,6 +64,7 @@ permissions:
 jobs:
   prepare:
     runs-on: ubuntu-latest
+    environment: production
     outputs:
       name: ${{ steps.release.outputs.name }}
       version: ${{ steps.release.outputs.version }}
@@ -146,7 +147,7 @@ jobs:
           REGISTRY_VER="$(npm view "${NAME}" version 2>/dev/null || true)"
           TAG_VER=$(
             git tag -l "${TAG_PREFIX}*" |
-              TAG_PREFIX="${TAG_PREFIX}" node <<'NODE'
+              TAG_PREFIX="${TAG_PREFIX}" node -e '
           const fs = require("node:fs");
           const prefix = process.env.TAG_PREFIX || "v";
           const parse = (value) => {
@@ -179,7 +180,7 @@ jobs:
             .sort(compare);
 
           process.stdout.write(versions.at(-1)?.version || "");
-          NODE
+          '
           )
 
           case "${BUMP:-patch}" in
@@ -189,6 +190,11 @@ jobs:
               exit 1
               ;;
           esac
+
+          if [ -n "${PREID:-}" ] && ! printf '%s' "${PREID}" | grep -Eq '^[0-9A-Za-z][0-9A-Za-z.-]*$'; then
+            echo "Invalid pre-release id: ${PREID}" >&2
+            exit 1
+          fi
 
           if [ "${BUMP}" = "none" ]; then
             TARGET_VER="${CURRENT_VER}"
@@ -274,15 +280,15 @@ jobs:
           fi
 
           if ! grep -q "^## \[${TARGET_VER}\]" "${FILE}"; then
-            UNREL_START=$(grep -n '^## \[Unreleased\]' "${FILE}" | cut -d: -f1 || true)
+            UNREL_START=$(grep -nE '^## (\[Unreleased\]|Unreleased)( |$)' "${FILE}" | head -n 1 | cut -d: -f1 || true)
             if [ -z "${UNREL_START}" ]; then
-              echo "No '## [Unreleased]' section found in CHANGELOG.md." >&2
+              echo "No '## [Unreleased]' or '## Unreleased' section found in CHANGELOG.md." >&2
               exit 1
             fi
 
             DATE=$(date -u +%Y-%m-%d)
             VERSION_LINE="## [${TARGET_VER}] - ${DATE}"
-            NEXT_HDR=$(awk 'NR>'"${UNREL_START}"' && /^## \[/{print NR; exit}' "${FILE}")
+            NEXT_HDR=$(awk 'NR>'"${UNREL_START}"' && /^## /{print NR; exit}' "${FILE}")
             if [ -z "${NEXT_HDR}" ]; then
               NEXT_HDR=$(wc -l < "${FILE}")
               NEXT_HDR=$((NEXT_HDR+1))
@@ -417,6 +423,14 @@ jobs:
             FLAGS=""
           else
             FLAGS="--access public"
+          fi
+
+          if [ -n "${PREID:-}" ]; then
+            if [ -n "${FLAGS}" ]; then
+              FLAGS="${FLAGS} --tag ${PREID}"
+            else
+              FLAGS="--tag ${PREID}"
+            fi
           fi
 
           COMMIT_SHA=$(git rev-parse HEAD)

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -144,6 +144,12 @@ jobs:
             exit 1
           fi
 
+          FILE="${CHANGELOG_PATH}"
+          if [ ! -f "${FILE}" ]; then
+            echo "CHANGELOG.md is required for release metadata preparation." >&2
+            exit 1
+          fi
+
           REGISTRY_VER="$(npm view "${NAME}" version 2>/dev/null || true)"
           TAG_VER=$(
             git tag -l "${TAG_PREFIX}*" |
@@ -197,6 +203,9 @@ jobs:
           fi
 
           if [ "${BUMP}" = "none" ]; then
+            TARGET_VER="${CURRENT_VER}"
+          elif ! npm view "${NAME}@${CURRENT_VER}" version >/dev/null 2>&1 && grep -Eq "^## (\[${CURRENT_VER}\]|${CURRENT_VER})( |$)" "${FILE}"; then
+            echo "Reusing already-prepared unpublished version ${CURRENT_VER}."
             TARGET_VER="${CURRENT_VER}"
           else
             TARGET_VER=$(node -e '
@@ -271,12 +280,6 @@ jobs:
               echo "GitHub release ${TAG} is already published; cut a new version instead." >&2
               exit 1
             fi
-          fi
-
-          FILE="${CHANGELOG_PATH}"
-          if [ ! -f "${FILE}" ]; then
-            echo "CHANGELOG.md is required for release metadata preparation." >&2
-            exit 1
           fi
 
           if ! grep -q "^## \[${TARGET_VER}\]" "${FILE}"; then


### PR DESCRIPTION
## Summary
- use the private shared release preparation workflow from `Plasius-LTD/plasius-ltd-site`
- move version and `CHANGELOG.md` preparation out of the package publish job
- keep npm publish and GitHub Release publication after release metadata is present on `main`

## Validation
- parsed the updated workflow YAML locally with Ruby
- verified the shared reusable workflow is merged on `Plasius-LTD/plasius-ltd-site/main`
