### PR TITLE
ci: harden release flow recovery paths

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -110,7 +110,6 @@ jobs:
       - name: Generate SBOM (CycloneDX)
         if: steps.release.outputs.should_finalize_release == 'true'
         run: npm sbom --sbom-format=cyclonedx --sbom-type=library --omit dev > sbom.cdx.json
-        continue-on-error: true
 
       - name: Attest SBOM
         if: steps.release.outputs.should_finalize_release == 'true' && hashFiles('sbom.cdx.json') != ''
@@ -123,6 +122,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.release.outputs.release_tag }}
+          PUBLISHED: ${{ needs.prepare_release.outputs.published }}
         run: |
           set -euo pipefail
 
@@ -137,6 +137,11 @@ jobs:
               exit 0
             fi
 
+            if [ "${PUBLISHED}" = "true" ]; then
+              echo "Package is already published; preserving existing tag ${TAG} at ${TAG_SHA}."
+              exit 0
+            fi
+
             if gh release view "${TAG}" >/dev/null 2>&1; then
               IS_DRAFT="$(gh release view "${TAG}" --json isDraft --jq '.isDraft')"
               if [ "${IS_DRAFT}" != "true" ]; then
@@ -148,6 +153,9 @@ jobs:
             echo "Replacing stale unpublished tag ${TAG}."
             git push origin ":refs/tags/${TAG}"
             git tag -d "${TAG}" >/dev/null 2>&1 || true
+          elif [ "${PUBLISHED}" = "true" ]; then
+            echo "Package is already published but tag ${TAG} is missing; cannot safely recreate a release tag after npm publication." >&2
+            exit 1
           fi
 
           git tag "${TAG}" "${HEAD_SHA}"
@@ -165,8 +173,8 @@ jobs:
           if gh release view "${TAG}" >/dev/null 2>&1; then
             IS_DRAFT="$(gh release view "${TAG}" --json isDraft --jq '.isDraft')"
             if [ "${IS_DRAFT}" != "true" ]; then
-              echo "Release ${TAG} already exists and is published. Cut a new version instead." >&2
-              exit 1
+              echo "Release ${TAG} is already published; nothing to recover."
+              exit 0
             fi
 
             if [ -s sbom.cdx.json ]; then
@@ -191,11 +199,18 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           FLAGS: ${{ steps.release.outputs.flags }}
+          PACKAGE_NAME: ${{ steps.release.outputs.package_name }}
+          PACKAGE_VERSION: ${{ steps.release.outputs.release_version }}
         run: |
           set -euo pipefail
           if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
             echo "NPM_TOKEN is required" >&2
             exit 1
+          fi
+
+          if npm view "${PACKAGE_NAME}@${PACKAGE_VERSION}" version --registry https://registry.npmjs.org >/dev/null 2>&1; then
+            echo "${PACKAGE_NAME}@${PACKAGE_VERSION} already exists on npm; skipping duplicate publish."
+            exit 0
           fi
 
           npm publish ${FLAGS} --provenance --registry https://registry.npmjs.org

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -202,10 +202,26 @@ jobs:
             exit 1
           fi
 
+          CURRENT_TAG="${TAG_PREFIX}${CURRENT_VER}"
+          if npm view "${NAME}@${CURRENT_VER}" version >/dev/null 2>&1; then
+            CURRENT_PUBLISHED="true"
+          else
+            CURRENT_PUBLISHED="false"
+          fi
+
+          CURRENT_RELEASE_STATE="missing"
+          if gh release view "${CURRENT_TAG}" >/dev/null 2>&1; then
+            if [ "$(gh release view "${CURRENT_TAG}" --json isDraft --jq '.isDraft')" = "true" ]; then
+              CURRENT_RELEASE_STATE="draft"
+            else
+              CURRENT_RELEASE_STATE="published"
+            fi
+          fi
+
           if [ "${BUMP}" = "none" ]; then
             TARGET_VER="${CURRENT_VER}"
-          elif ! npm view "${NAME}@${CURRENT_VER}" version >/dev/null 2>&1 && grep -Eq "^## (\[${CURRENT_VER}\]|${CURRENT_VER})( |$)" "${FILE}"; then
-            echo "Reusing already-prepared unpublished version ${CURRENT_VER}."
+          elif grep -Eq "^## (\[${CURRENT_VER}\]|${CURRENT_VER})( |$)" "${FILE}" && { [ "${CURRENT_PUBLISHED}" != "true" ] || [ "${CURRENT_RELEASE_STATE}" != "published" ]; }; then
+            echo "Reusing already-prepared incomplete release version ${CURRENT_VER}."
             TARGET_VER="${CURRENT_VER}"
           else
             TARGET_VER=$(node -e '
@@ -358,6 +374,12 @@ jobs:
               echo "Release metadata pushed directly to ${BASE_BRANCH}."
             else
               BRANCH="release/${TAG}"
+              if [ -z "${RELEASE_PREP_TOKEN:-}" ]; then
+                echo "RELEASE_PREP_TOKEN is required when branch protection forces release metadata through a PR; github.token-created PRs do not reliably trigger required workflows." >&2
+                exit 1
+              fi
+              git remote set-url origin "https://x-access-token:${RELEASE_PREP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+              git fetch origin "refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}" || true
               git push --force-with-lease --set-upstream origin "HEAD:${BRANCH}"
 
               PR_TITLE="chore: prepare release ${TAG}"
@@ -428,15 +450,27 @@ jobs:
             FLAGS="--access public"
           fi
 
-          if [ -n "${PREID:-}" ]; then
+          EFFECTIVE_PREID="${PREID:-}"
+          if [ -z "${EFFECTIVE_PREID}" ]; then
+            EFFECTIVE_PREID=$(TARGET_VER="${TARGET_VER}" node -e '
+          const version = process.env.TARGET_VER || "";
+          const match = version.match(/^[0-9]+\.[0-9]+\.[0-9]+-([0-9A-Za-z][0-9A-Za-z.-]*)\.[0-9]+$/);
+          process.stdout.write(match ? match[1] : "");
+          ')
+          fi
+
+          if [ -n "${EFFECTIVE_PREID}" ]; then
             if [ -n "${FLAGS}" ]; then
-              FLAGS="${FLAGS} --tag ${PREID}"
+              FLAGS="${FLAGS} --tag ${EFFECTIVE_PREID}"
             else
-              FLAGS="--tag ${PREID}"
+              FLAGS="--tag ${EFFECTIVE_PREID}"
             fi
           fi
 
-          COMMIT_SHA=$(git rev-parse HEAD)
+          COMMIT_SHA=$(git log -n 1 --format=%H -- "${PACKAGE_JSON}")
+          if [ -z "${COMMIT_SHA}" ]; then
+            COMMIT_SHA=$(git rev-parse HEAD)
+          fi
           {
             echo "name=${NAME}"
             echo "version=${TARGET_VER}"


### PR DESCRIPTION
Fresh PR for the final hardened local release flow. Replaces an earlier rollout PR whose review conversations referred to superseded workflow code.