### PR TITLE
chore: prepare release v0.1.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,20 @@ The format is based on **[Keep a Changelog](https://keepachangelog.com/en/1.1.0/
   - (placeholder)
 
 - **Fixed**
+  - (placeholder)
+
+- **Security**
+  - (placeholder)
+
+## [0.1.15] - 2026-06-22
+
+- **Added**
+  - (placeholder)
+
+- **Changed**
+  - (placeholder)
+
+- **Fixed**
   - Replaced placeholder particle render jobs with active WGSL kernels in all
     shipped effect modules and added placeholder-regression coverage.
 
@@ -213,3 +227,4 @@ The format is based on **[Keep a Changelog](https://keepachangelog.com/en/1.1.0/
 [0.1.10]: https://github.com/Plasius-LTD/gpu-particles/releases/tag/v0.1.10
 [0.1.11]: https://github.com/Plasius-LTD/gpu-particles/releases/tag/v0.1.11
 [0.1.12]: https://github.com/Plasius-LTD/gpu-particles/releases/tag/v0.1.12
+[0.1.15]: https://github.com/Plasius-LTD/gpu-particles/releases/tag/v0.1.15

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@plasius/gpu-particles",
-  "version": "0.1.12",
+  "version": "0.1.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@plasius/gpu-particles",
-      "version": "0.1.12",
+      "version": "0.1.15",
       "funding": [
         {
           "type": "patreon",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plasius/gpu-particles",
-  "version": "0.1.12",
+  "version": "0.1.15",
   "description": "Particle effect WGSL modules and helpers for @plasius/gpu-worker.",
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
## Summary
- prepare `v0.1.15` for publication from protected `main`
- update package metadata to `0.1.15`
- move the current `Unreleased` notes into `0.1.15`

The CD workflow will continue only after this release metadata is present on `main`.